### PR TITLE
Remove *.g.dart files from coverage

### DIFF
--- a/.github/workflows/news-check-pr.yml
+++ b/.github/workflows/news-check-pr.yml
@@ -64,5 +64,6 @@ jobs:
         uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
+          working-directory: ./flutter/news
           name: test-results
-          path: ./flutter/news/test-results.json
+          path: test-results.json

--- a/.github/workflows/news-check-pr.yml
+++ b/.github/workflows/news-check-pr.yml
@@ -47,6 +47,10 @@ jobs:
         working-directory: ./flutter/news
         run: flutter test --coverage --machine > test-results.json
 
+      - name: Remove unrequired files from coverage
+        working-directory: ./flutter/news
+        run: flutter pub global run remove_from_coverage:remove_from_coverage -f coverage/lcov.info -r '\.g\.dart$'
+
       - name: Report code coverage
         uses: zgosalvez/github-actions-report-lcov@v1
         with:

--- a/.github/workflows/news-check-pr.yml
+++ b/.github/workflows/news-check-pr.yml
@@ -55,7 +55,7 @@ jobs:
         uses: zgosalvez/github-actions-report-lcov@v1
         with:
           coverage-files: ./flutter/news/coverage/lcov.info
-          minimum-coverage: 0
+          minimum-coverage: 75
           artifact-name: news-code-coverage-report
           github-token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ./flutter/news
@@ -64,6 +64,5 @@ jobs:
         uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
-          working-directory: ./flutter/news
           name: test-results
-          path: test-results.json
+          path: ./flutter/news/test-results.json

--- a/.github/workflows/news-check-pr.yml
+++ b/.github/workflows/news-check-pr.yml
@@ -49,8 +49,7 @@ jobs:
 
       - name: Remove unrequired files from coverage
         working-directory: ./flutter/news
-        run: flutter pub global activate remove_from_coverage
- && flutter pub global run remove_from_coverage:remove_from_coverage -f coverage/lcov.info -r '\.g\.dart$'
+        run: flutter pub global activate remove_from_coverage && flutter pub global run remove_from_coverage:remove_from_coverage -f coverage/lcov.info -r '\.g\.dart$'
 
       - name: Report code coverage
         uses: zgosalvez/github-actions-report-lcov@v1

--- a/.github/workflows/news-check-pr.yml
+++ b/.github/workflows/news-check-pr.yml
@@ -49,7 +49,8 @@ jobs:
 
       - name: Remove unrequired files from coverage
         working-directory: ./flutter/news
-        run: flutter pub global run remove_from_coverage:remove_from_coverage -f coverage/lcov.info -r '\.g\.dart$'
+        run: flutter pub global activate remove_from_coverage
+ && flutter pub global run remove_from_coverage:remove_from_coverage -f coverage/lcov.info -r '\.g\.dart$'
 
       - name: Report code coverage
         uses: zgosalvez/github-actions-report-lcov@v1

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,4 +1,4 @@
-name: 'Test Report'
+name: 'News Test Report'
 on:
   workflow_run:
     workflows: ['Run Checks - News']
@@ -11,6 +11,6 @@ jobs:
     - uses: dorny/test-reporter@v1
       with:
         artifact: test-results
-        name: News Tests
+        name: Tests Results
         path: 'test-results.json'
         reporter: flutter-json

--- a/flutter/news/pubspec.yaml
+++ b/flutter/news/pubspec.yaml
@@ -28,9 +28,9 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  remove_from_coverage: ^2.0.0
   mockito: ^5.1.0
   build_runner: ^2.1.2
-
   flutter_lints: ^1.0.0
   retrofit_generator: ^4.0.1
   json_serializable: ^6.1.5


### PR DESCRIPTION
# Short Description

Adds a step to the github action workflow to remove autogenerated files (`*.g.dart) from code coverage