### PR TITLE
Adds Freezed

### DIFF
--- a/flutter/news/.gitignore
+++ b/flutter/news/.gitignore
@@ -12,6 +12,7 @@
 .svn/
 *.mocks.dart
 *.g.dart
+*.freezed.dart
 
 # IntelliJ related
 *.iml

--- a/flutter/news/analysis_options.yaml
+++ b/flutter/news/analysis_options.yaml
@@ -27,3 +27,10 @@ linter:
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
+
+analyzer:
+  exclude:
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
+  errors:
+    invalid_annotation_target: ignore

--- a/flutter/news/lib/core/constants.dart
+++ b/flutter/news/lib/core/constants.dart
@@ -1,4 +1,0 @@
-class Constants {
-  static const String baseUrl = "newsapi.org";
-  static const String topHeadlinesEndpoint = "/v2/top-headlines";
-}

--- a/flutter/news/lib/core/error/failures.dart
+++ b/flutter/news/lib/core/error/failures.dart
@@ -1,9 +1,14 @@
-import 'package:news/core/result.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'failures.freezed.dart';
 
-class ServerFailure extends Failure {
-  const ServerFailure(String message) : super(message);
+abstract class InternalFailure {}
+
+@freezed
+class ServerFailure with _$ServerFailure implements InternalFailure {
+  const factory ServerFailure({required String message}) = _ServerFailure;
 }
 
-class CacheFailure extends Failure {
-  const CacheFailure(String message) : super(message);
+@freezed
+class CacheFailure with _$CacheFailure implements InternalFailure {
+  const factory CacheFailure({required String message}) = _CacheFailure;
 }

--- a/flutter/news/lib/core/language_extensions.dart
+++ b/flutter/news/lib/core/language_extensions.dart
@@ -1,0 +1,1 @@
+doNothing({required String because}) => {};

--- a/flutter/news/lib/core/result.dart
+++ b/flutter/news/lib/core/result.dart
@@ -4,9 +4,9 @@ import 'error/failures.dart';
 part 'result.freezed.dart';
 
 @freezed
-class Result<S> with _$Result {
-  const factory Result.failure({required InternalFailure failure}) = Failure;
-  const factory Result.success({required S data}) = Success<S>;
+class Result<S> with _$Result<S> {
+  const factory Result.success({required S data}) = _Success<S>;
+  const factory Result.failure({required InternalFailure failure}) = _Failure;
 }
 
 extension AsSuccess<T> on T {
@@ -18,32 +18,5 @@ extension AsSuccess<T> on T {
 extension AsFailure on InternalFailure {
   Result<T> asFailure<T>() {
     return Result<T>.failure(failure: this);
-  }
-}
-
-extension ResultExtensions<S> on Result<S> {
-  fold({
-    required Function(S) ifSuccess,
-    required Function(InternalFailure) ifFailure,
-  }) {
-    if (this is Success<S>) {
-      ifSuccess((this as Success).data);
-    } else {
-      ifFailure((this as Failure).failure);
-    }
-  }
-
-  onSuccess(Function onSuccess) {
-    if (this is Success<S>) {
-      onSuccess(this as Success<S>);
-    }
-    return this;
-  }
-
-  onFailure(Function onFailure) {
-    if (this is Failure) {
-      onFailure(this as Failure);
-    }
-    return this;
   }
 }

--- a/flutter/news/lib/core/result.dart
+++ b/flutter/news/lib/core/result.dart
@@ -5,7 +5,6 @@ part 'result.freezed.dart';
 
 @freezed
 class Result<S> with _$Result {
-  const Result._();
   const factory Result.failure({required InternalFailure failure}) = Failure;
   const factory Result.success({required S data}) = Success<S>;
 }

--- a/flutter/news/lib/features/frontpage/data/datasource/articles_local_data_source.dart
+++ b/flutter/news/lib/features/frontpage/data/datasource/articles_local_data_source.dart
@@ -21,14 +21,14 @@ class ArticlesLocalDataSource {
           List<Article>.from(jsonMap.map((model) => Article.fromJson(model)));
 
       if (articles.isNotEmpty) {
-        return Future.value(Result.success(articles));
+        return Future.value(Result<List<Article>>.success(data: articles));
       } else {
-        return Future.value(
-            Result.failure(const CacheFailure("No headlines saved")));
+        return Future.value(const Result<List<Article>>.failure(
+            failure: CacheFailure(message: "No headlines saved")));
       }
     } catch (e) {
-      return Future.value(Result.failure(
-          const CacheFailure("Error decoding stored headlines")));
+      return Future.value(const Result<List<Article>>.failure(
+          failure: CacheFailure(message: "Error decoding stored headlines")));
     }
   }
 

--- a/flutter/news/lib/features/frontpage/data/datasource/articles_remote_data_source.dart
+++ b/flutter/news/lib/features/frontpage/data/datasource/articles_remote_data_source.dart
@@ -10,9 +10,9 @@ class ArticlesRemoteDataSource {
   Future<Result<List<Article>>> topHeadLines() async {
     var result = await client
         .topHeadLines()
-        .then((value) => Result<List<Article>>.success(value.articles))
-        .catchError((error) => Result<List<Article>>.failure(
-            const ServerFailure("Unable to read news from API")));
+        .then((value) => Result<List<Article>>.success(data: value.articles))
+        .catchError((error) => const Result<List<Article>>.failure(
+            failure: ServerFailure(message: "Unable to read news from API")));
 
     return result;
   }

--- a/flutter/news/lib/features/frontpage/data/repositories/articles_repository.dart
+++ b/flutter/news/lib/features/frontpage/data/repositories/articles_repository.dart
@@ -19,9 +19,10 @@ class ArticlesRepository {
 
   Future<Result<List<Article>>> topHeadlines() async {
     final result = await remoteDataSource.topHeadLines();
-    result.fold(
-        ifSuccess: (data) => localDataSource.save(topHeadlines: data),
-        ifFailure: (failure) => doNothing(because: "There is nothing to save"));
+    result.when(
+      success: (data) => localDataSource.save(topHeadlines: data),
+      failure: (failure) => doNothing(because: "There is nothing to save"),
+    );
 
     return localDataSource.topHeadLines();
   }

--- a/flutter/news/lib/features/frontpage/data/repositories/articles_repository.dart
+++ b/flutter/news/lib/features/frontpage/data/repositories/articles_repository.dart
@@ -1,3 +1,4 @@
+import 'package:news/core/language_extensions.dart';
 import 'package:news/core/result.dart';
 
 import '../../domain/entities/article.dart';
@@ -18,9 +19,10 @@ class ArticlesRepository {
 
   Future<Result<List<Article>>> topHeadlines() async {
     final result = await remoteDataSource.topHeadLines();
-    if (result.isSuccess) {
-      localDataSource.save(topHeadlines: result.data);
-    }
+    result.fold(
+        ifSuccess: (data) => localDataSource.save(topHeadlines: data),
+        ifFailure: (failure) => doNothing(because: "There is nothing to save"));
+
     return localDataSource.topHeadLines();
   }
 }

--- a/flutter/news/lib/features/frontpage/domain/entities/article.dart
+++ b/flutter/news/lib/features/frontpage/domain/entities/article.dart
@@ -1,42 +1,20 @@
-import 'package:equatable/equatable.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:news/features/frontpage/domain/entities/source.dart';
+
+part 'article.freezed.dart';
 part 'article.g.dart';
 
-@JsonSerializable()
-class Article extends Equatable {
-  final Source source;
-  final String author;
-  final String title;
-  final String description;
-  final String url;
-  final String urlToImage;
-  final String publishedAt;
-  final String content;
+@freezed
+class Article with _$Article {
+  const factory Article(
+      {required Source source,
+      required String author,
+      required String title,
+      required String description,
+      required String url,
+      required String urlToImage,
+      required String publishedAt,
+      required String content}) = _Article;
 
-  const Article(
-      {required this.source,
-      required this.author,
-      required this.title,
-      required this.description,
-      required this.url,
-      required this.urlToImage,
-      required this.publishedAt,
-      required this.content});
-
-  factory Article.fromJson(Map<String, dynamic> json) =>
-      _$ArticleFromJson(json);
-  Map<String, dynamic> toJson() => _$ArticleToJson(this);
-
-  @override
-  List<Object> get props => [
-        source,
-        author,
-        title,
-        description,
-        url,
-        urlToImage,
-        publishedAt,
-        content
-      ];
+  factory Article.fromJson(Map<String, dynamic> json) => _$ArticleFromJson(json);
 }

--- a/flutter/news/lib/features/frontpage/domain/entities/base_news_response.dart
+++ b/flutter/news/lib/features/frontpage/domain/entities/base_news_response.dart
@@ -1,23 +1,15 @@
-import 'package:equatable/equatable.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:news/features/frontpage/domain/entities/article.dart';
-import 'package:json_annotation/json_annotation.dart';
+part 'base_news_response.freezed.dart';
 part 'base_news_response.g.dart';
 
-@JsonSerializable()
-class BaseNewsResponse extends Equatable {
-  final String status;
-  final int totalResults;
-  final List<Article> articles;
-
-  const BaseNewsResponse(
-      {required this.status,
-      required this.totalResults,
-      required this.articles});
+@freezed
+class BaseNewsResponse with _$BaseNewsResponse {
+  const factory BaseNewsResponse(
+      {required String status,
+      required int totalResults,
+      required List<Article> articles}) = _BaseNewsResponse;
 
   factory BaseNewsResponse.fromJson(Map<String, dynamic> json) =>
       _$BaseNewsResponseFromJson(json);
-  Map<String, dynamic> toJson() => _$BaseNewsResponseToJson(this);
-
-  @override
-  List<Object> get props => [status, totalResults, articles];
 }

--- a/flutter/news/lib/features/frontpage/domain/entities/source.dart
+++ b/flutter/news/lib/features/frontpage/domain/entities/source.dart
@@ -1,17 +1,11 @@
-import 'package:equatable/equatable.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'source.freezed.dart';
 part 'source.g.dart';
 
-@JsonSerializable()
-class Source extends Equatable {
-  final String? id;
-  final String name;
-
-  const Source({required this.id, required this.name});
+@freezed
+class Source with _$Source {
+  const factory Source({String? id, required String name}) = _Source;
 
   factory Source.fromJson(Map<String, dynamic> json) => _$SourceFromJson(json);
-  Map<String, dynamic> toJson() => _$SourceToJson(this);
-
-  @override
-  List<Object?> get props => [id, name];
 }

--- a/flutter/news/lib/features/frontpage/presentation/bloc/articles_cubit.dart
+++ b/flutter/news/lib/features/frontpage/presentation/bloc/articles_cubit.dart
@@ -1,33 +1,33 @@
 import 'package:bloc/bloc.dart';
-import 'package:equatable/equatable.dart';
 import 'package:news/core/result.dart';
 import 'package:news/features/frontpage/data/repositories/articles_repository.dart';
+import 'package:news/features/frontpage/presentation/bloc/top_headlines_state.dart';
 import 'package:news/features/frontpage/presentation/bloc/top_headlines_viewstate.dart';
-
-part 'top_headlines_state.dart';
 
 class ArticlesCubit extends Cubit<ArticlesState> {
   final ArticlesRepository repository;
 
-  ArticlesCubit({required this.repository}) : super(TopHeadlinesInitial());
+  ArticlesCubit({required this.repository})
+      : super(const ArticlesState.initial());
 
   void getTopHeadlines() async {
-    emit(TopHeadlinesLoading());
+    emit(const ArticlesState.loading());
 
     final result = await repository.topHeadlines();
     result.fold(
         ifSuccess: (data) => {
-              emit(TopHeadlinesLoaded(data
-                  .take(10)
-                  .map(
-                    (article) => TopHeadlineViewState(
-                      article.title,
-                      article.url,
-                      article.urlToImage,
-                    ),
-                  )
-                  .toList()))
+              emit(ArticlesState.loaded(
+                  viewState: data
+                      .take(10)
+                      .map(
+                        (article) => TopHeadlineViewState(
+                          title: article.title,
+                          url: article.url,
+                          imageUrl: article.urlToImage,
+                        ),
+                      )
+                      .toList()))
             },
-        ifFailure: (failure) => emit(TopHeadlinesError()));
+        ifFailure: (failure) => emit(const ArticlesState.error()));
   }
 }

--- a/flutter/news/lib/features/frontpage/presentation/bloc/articles_cubit.dart
+++ b/flutter/news/lib/features/frontpage/presentation/bloc/articles_cubit.dart
@@ -14,20 +14,21 @@ class ArticlesCubit extends Cubit<ArticlesState> {
     emit(const ArticlesState.loading());
 
     final result = await repository.topHeadlines();
-    result.fold(
-        ifSuccess: (data) => {
-              emit(ArticlesState.loaded(
-                  viewState: data
-                      .take(10)
-                      .map(
-                        (article) => TopHeadlineViewState(
-                          title: article.title,
-                          url: article.url,
-                          imageUrl: article.urlToImage,
-                        ),
-                      )
-                      .toList()))
-            },
-        ifFailure: (failure) => emit(const ArticlesState.error()));
+    result.when(
+      success: (data) => {
+        emit(ArticlesState.loaded(
+            viewState: data
+                .take(10)
+                .map(
+                  (article) => TopHeadlineViewState(
+                    title: article.title,
+                    url: article.url,
+                    imageUrl: article.urlToImage,
+                  ),
+                )
+                .toList()))
+      },
+      failure: (failure) => emit(const ArticlesState.error()),
+    );
   }
 }

--- a/flutter/news/lib/features/frontpage/presentation/bloc/articles_cubit.dart
+++ b/flutter/news/lib/features/frontpage/presentation/bloc/articles_cubit.dart
@@ -1,5 +1,4 @@
 import 'package:bloc/bloc.dart';
-import 'package:news/core/result.dart';
 import 'package:news/features/frontpage/data/repositories/articles_repository.dart';
 import 'package:news/features/frontpage/presentation/bloc/top_headlines_state.dart';
 import 'package:news/features/frontpage/presentation/bloc/top_headlines_viewstate.dart';

--- a/flutter/news/lib/features/frontpage/presentation/bloc/articles_cubit.dart
+++ b/flutter/news/lib/features/frontpage/presentation/bloc/articles_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:news/core/result.dart';
 import 'package:news/features/frontpage/data/repositories/articles_repository.dart';
 import 'package:news/features/frontpage/presentation/bloc/top_headlines_viewstate.dart';
 
@@ -12,12 +13,21 @@ class ArticlesCubit extends Cubit<ArticlesState> {
 
   void getTopHeadlines() async {
     emit(TopHeadlinesLoading());
-    final topHeadlines = await repository.topHeadlines();
-    if (topHeadlines.isSuccess) {
-      emit(TopHeadlinesLoaded(topHeadlines.data.take(10)
-          .map((e) => TopHeadlineViewState(e.title, e.url, e.urlToImage)).toList()));
-    } else {
-      emit(TopHeadlinesError());
-    }
+
+    final result = await repository.topHeadlines();
+    result.fold(
+        ifSuccess: (data) => {
+              emit(TopHeadlinesLoaded(data
+                  .take(10)
+                  .map(
+                    (article) => TopHeadlineViewState(
+                      article.title,
+                      article.url,
+                      article.urlToImage,
+                    ),
+                  )
+                  .toList()))
+            },
+        ifFailure: (failure) => emit(TopHeadlinesError()));
   }
 }

--- a/flutter/news/lib/features/frontpage/presentation/bloc/top_headlines_state.dart
+++ b/flutter/news/lib/features/frontpage/presentation/bloc/top_headlines_state.dart
@@ -5,10 +5,10 @@ part 'top_headlines_state.freezed.dart';
 
 @freezed
 class ArticlesState with _$ArticlesState {
-  const factory ArticlesState.initial() = Initial;
-  const factory ArticlesState.loading() = Loading;
+  const factory ArticlesState.initial() = _Initial;
+  const factory ArticlesState.loading() = _Loading;
   const factory ArticlesState.loaded({
     required List<TopHeadlineViewState> viewState,
   }) = Loaded;
-  const factory ArticlesState.error() = Error;
+  const factory ArticlesState.error() = _Error;
 }

--- a/flutter/news/lib/features/frontpage/presentation/bloc/top_headlines_state.dart
+++ b/flutter/news/lib/features/frontpage/presentation/bloc/top_headlines_state.dart
@@ -1,29 +1,14 @@
-part of 'articles_cubit.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:news/features/frontpage/presentation/bloc/top_headlines_viewstate.dart';
 
-abstract class ArticlesState extends Equatable {
-  const ArticlesState();
-}
+part 'top_headlines_state.freezed.dart';
 
-class TopHeadlinesInitial extends ArticlesState {
-  @override
-  List<Object> get props => [];
-}
-
-class TopHeadlinesLoading extends ArticlesState {
-  @override
-  List<Object> get props => [];
-}
-
-class TopHeadlinesLoaded extends ArticlesState {
-  final List<TopHeadlineViewState> topHeadlines;
-
-  const TopHeadlinesLoaded(this.topHeadlines);
-
-  @override
-  List<Object> get props => [topHeadlines];
-}
-
-class TopHeadlinesError extends ArticlesState {
-  @override
-  List<Object> get props => [];
+@freezed
+class ArticlesState with _$ArticlesState {
+  const factory ArticlesState.initial() = Initial;
+  const factory ArticlesState.loading() = Loading;
+  const factory ArticlesState.loaded({
+    required List<TopHeadlineViewState> viewState,
+  }) = Loaded;
+  const factory ArticlesState.error() = Error;
 }

--- a/flutter/news/lib/features/frontpage/presentation/bloc/top_headlines_viewstate.dart
+++ b/flutter/news/lib/features/frontpage/presentation/bloc/top_headlines_viewstate.dart
@@ -1,12 +1,12 @@
-import 'package:equatable/equatable.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 
-class TopHeadlineViewState extends Equatable {
-  final String title;
-  final String url;
-  final String imageUrl;
+part 'top_headlines_viewstate.freezed.dart';
 
-  const TopHeadlineViewState(this.title, this.url, this.imageUrl);
-
-  @override
-  List<Object?> get props => [title, url, imageUrl];
+@freezed
+class TopHeadlineViewState with _$TopHeadlineViewState {
+  const factory TopHeadlineViewState({
+    required String title,
+    required String url,
+    required String imageUrl,
+  }) = _TopHeadLineViewState;
 }

--- a/flutter/news/pubspec.yaml
+++ b/flutter/news/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   dio: ^4.0.4
   json_annotation: ^4.4.0
   bloc_test: ^9.0.1
+  freezed_annotation: ^1.1.0
 
 dev_dependencies:
   flutter_test:
@@ -34,6 +35,7 @@ dev_dependencies:
   flutter_lints: ^1.0.0
   retrofit_generator: ^3.0.1
   json_serializable: ^6.1.5
+  freezed: ^1.1.0
 
 flutter:
   # The following line ensures that the Material Icons font is

--- a/flutter/news/test/features/frontpage/data/datasource/articles_local_data_source_test.dart
+++ b/flutter/news/test/features/frontpage/data/datasource/articles_local_data_source_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:news/core/error/failures.dart';
+import 'package:news/core/result.dart';
 import 'package:news/features/frontpage/data/datasource/articles_local_data_source.dart';
 import 'package:news/features/frontpage/domain/entities/article.dart';
 import 'package:news/features/frontpage/domain/entities/source.dart';
@@ -34,7 +35,7 @@ void main() {
 
       var result = await localDataSource.topHeadLines();
 
-      expect(result.data, articles);
+      expect(result, articles.asSuccess());
     },
   );
 
@@ -45,7 +46,10 @@ void main() {
 
       var result = await localDataSource.topHeadLines();
 
-      expect(result.failure, const CacheFailure("No headlines saved"));
+      expect(
+          result,
+          const CacheFailure(message: "No headlines saved")
+              .asFailure<List<Article>>());
     },
   );
 
@@ -59,8 +63,10 @@ void main() {
 
       var result = await localDataSource.topHeadLines();
 
-      expect(result.failure,
-          const CacheFailure("Error decoding stored headlines"));
+      expect(
+          result,
+          const CacheFailure(message: "Error decoding stored headlines")
+              .asFailure<List<Article>>());
     },
   );
 }

--- a/flutter/news/test/features/frontpage/data/datasource/articles_remote_data_source_test.dart
+++ b/flutter/news/test/features/frontpage/data/datasource/articles_remote_data_source_test.dart
@@ -4,7 +4,9 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:news/core/error/failures.dart';
 import 'package:news/core/news_api_client.dart';
+import 'package:news/core/result.dart';
 import 'package:news/features/frontpage/data/datasource/articles_remote_data_source.dart';
+import 'package:news/features/frontpage/domain/entities/article.dart';
 import 'package:news/features/frontpage/domain/entities/base_news_response.dart';
 import '../../../../core/fixtures/fixture_reader.dart';
 import 'articles_remote_data_source_test.mocks.dart';
@@ -28,7 +30,7 @@ void main() {
 
       final result = await remoteDataSource.topHeadLines();
 
-      expect(result.data, response.articles);
+      expect(result, response.articles.asSuccess());
     },
   );
 
@@ -40,7 +42,9 @@ void main() {
       final result = await remoteDataSource.topHeadLines();
 
       expect(
-          result.failure, const ServerFailure("Unable to read news from API"));
+          result,
+          const ServerFailure(message: "Unable to read news from API")
+              .asFailure<List<Article>>());
     },
   );
 }

--- a/flutter/news/test/features/frontpage/domain/usecases/get_everything_about_test.dart
+++ b/flutter/news/test/features/frontpage/domain/usecases/get_everything_about_test.dart
@@ -38,23 +38,27 @@ void main() {
     'GIVEN getting everything about will succeed WHEN calling use case THEN returns matching articles ',
     () async {
       when(articlesRepository.everythingAbout(query))
-          .thenAnswer((_) async => Result.success(matchingArticles));
+          .thenAnswer((_) async => matchingArticles.asSuccess());
 
       final result = await usecase.everythingAbout(query);
 
-      expect(result.data, matchingArticles);
+      expect(result, matchingArticles.asSuccess());
     },
   );
 
   test(
     'GIVEN getting everything about will fail WHEN calling use case THEN returns failure ',
     () async {
-      when(articlesRepository.everythingAbout(query)).thenAnswer(
-          (_) async => Result.failure(const ServerFailure("Error on server")));
+      when(articlesRepository.everythingAbout(query)).thenAnswer((_) async =>
+          const ServerFailure(message: "Error on server")
+              .asFailure<List<Article>>());
 
       final result = await usecase.everythingAbout(query);
 
-      expect(result.failure, const ServerFailure("Error on server"));
+      expect(
+          result,
+          const ServerFailure(message: "Error on server")
+              .asFailure<List<Article>>());
     },
   );
 }

--- a/flutter/news/test/features/frontpage/domain/usecases/get_top_headlines_test.dart
+++ b/flutter/news/test/features/frontpage/domain/usecases/get_top_headlines_test.dart
@@ -36,11 +36,11 @@ void main() {
     'GIVEN reading top headlines will succeed WHEN reading top articles THEN returns top articles',
     () async {
       when(articlesRepository.topHeadlines())
-          .thenAnswer((_) async => Result.success(topArticles));
+          .thenAnswer((_) async => topArticles.asSuccess());
 
       final result = await usecase.topHeadlines();
 
-      expect(result.data, topArticles);
+      expect(result, topArticles.asSuccess());
     },
   );
 
@@ -48,11 +48,15 @@ void main() {
     'GIVEN reading top headlines will faill WHEN reading top articles THEN returns failure',
     () async {
       when(articlesRepository.topHeadlines()).thenAnswer((_) async =>
-          Result.failure(const ServerFailure("Error reading from server")));
+          const ServerFailure(message: "Error reading from server")
+              .asFailure<List<Article>>());
 
       final result = await usecase.topHeadlines();
 
-      expect(result.failure, const ServerFailure("Error reading from server"));
+      expect(
+          result,
+          const ServerFailure(message: "Error reading from server")
+              .asFailure<List<Article>>());
     },
   );
 }

--- a/flutter/news/test/features/frontpage/presentation/bloc/articles_cubit_test.dart
+++ b/flutter/news/test/features/frontpage/presentation/bloc/articles_cubit_test.dart
@@ -5,6 +5,7 @@ import 'package:mockito/mockito.dart';
 import 'package:news/core/error/failures.dart';
 import 'package:news/core/result.dart';
 import 'package:news/features/frontpage/data/repositories/articles_repository.dart';
+import 'package:news/features/frontpage/domain/entities/article.dart';
 import 'package:news/features/frontpage/presentation/bloc/articles_cubit.dart';
 import 'package:news/features/frontpage/presentation/bloc/top_headlines_viewstate.dart';
 
@@ -21,8 +22,9 @@ void main() {
     'THEN emits [TopHeadlinesLoading, TopHeadlinesLoaded]',
     build: () {
       when(repository.topHeadlines()).thenAnswer(
-        (_) async => Result.success(
-            [Stub.article(title: "title", url: "url", imageUrl: "image")]),
+        (_) async => [
+          Stub.article(title: "title", url: "url", imageUrl: "image")
+        ].asSuccess(),
       );
       return ArticlesCubit(repository: repository);
     },
@@ -38,9 +40,10 @@ void main() {
     'WHEN response is failure '
     'THEN emits [TopHeadlinesLoading, TopHeadlinesError]',
     build: () {
-      when(repository.topHeadlines()).thenAnswer((_) async => Result.failure(
-            const CacheFailure("No headlines saved"),
-          ));
+      when(repository.topHeadlines()).thenAnswer(
+        (_) async => const CacheFailure(message: "No headlines saved")
+            .asFailure<List<Article>>(),
+      );
       return ArticlesCubit(repository: repository);
     },
     act: (cubit) => cubit.getTopHeadlines(),
@@ -52,9 +55,9 @@ void main() {
     'WHEN response is successful '
     'THEN verify TopHeadlineViewState is limited to the first 10 elements',
     build: () {
-      when(repository.topHeadlines()).thenAnswer((_) async => Result.success(
-            List.generate(15, (index) => Stub.article(title: "$index")),
-          ));
+      when(repository.topHeadlines()).thenAnswer((_) async =>
+          List.generate(15, (index) => Stub.article(title: "$index"))
+              .asSuccess());
       return ArticlesCubit(repository: repository);
     },
     act: (cubit) => cubit.getTopHeadlines(),

--- a/flutter/news/test/features/frontpage/presentation/bloc/articles_cubit_test.dart
+++ b/flutter/news/test/features/frontpage/presentation/bloc/articles_cubit_test.dart
@@ -7,6 +7,7 @@ import 'package:news/core/result.dart';
 import 'package:news/features/frontpage/data/repositories/articles_repository.dart';
 import 'package:news/features/frontpage/domain/entities/article.dart';
 import 'package:news/features/frontpage/presentation/bloc/articles_cubit.dart';
+import 'package:news/features/frontpage/presentation/bloc/top_headlines_state.dart';
 import 'package:news/features/frontpage/presentation/bloc/top_headlines_viewstate.dart';
 
 import '../../../../core/utils/extensions.dart';
@@ -19,7 +20,7 @@ void main() {
   blocTest<ArticlesCubit, ArticlesState>(
     'GIVEN topHeadlines is requested '
     'WHEN response is successful '
-    'THEN emits [TopHeadlinesLoading, TopHeadlinesLoaded]',
+    'THEN emits [Loading, Loaded]',
     build: () {
       when(repository.topHeadlines()).thenAnswer(
         (_) async => [
@@ -30,15 +31,21 @@ void main() {
     },
     act: (cubit) => cubit.getTopHeadlines(),
     expect: () => <ArticlesState>[
-      TopHeadlinesLoading(),
-      const TopHeadlinesLoaded([TopHeadlineViewState("title", "url", "image")])
+      const ArticlesState.loading(),
+      const ArticlesState.loaded(viewState: [
+        TopHeadlineViewState(
+          title: "title",
+          url: "url",
+          imageUrl: "image",
+        )
+      ])
     ],
   );
 
   blocTest<ArticlesCubit, ArticlesState>(
     'GIVEN topHeadlines is requested '
     'WHEN response is failure '
-    'THEN emits [TopHeadlinesLoading, TopHeadlinesError]',
+    'THEN emits [Loading, Error]',
     build: () {
       when(repository.topHeadlines()).thenAnswer(
         (_) async => const CacheFailure(message: "No headlines saved")
@@ -47,13 +54,16 @@ void main() {
       return ArticlesCubit(repository: repository);
     },
     act: (cubit) => cubit.getTopHeadlines(),
-    expect: () => <ArticlesState>[TopHeadlinesLoading(), TopHeadlinesError()],
+    expect: () => <ArticlesState>[
+      const ArticlesState.loading(),
+      const ArticlesState.error(),
+    ],
   );
 
   blocTest<ArticlesCubit, ArticlesState>(
     'GIVEN topHeadlines is requested '
     'WHEN response is successful '
-    'THEN verify TopHeadlineViewState is limited to the first 10 elements',
+    'THEN verify View State is limited to the first 10 elements',
     build: () {
       when(repository.topHeadlines()).thenAnswer((_) async =>
           List.generate(15, (index) => Stub.article(title: "$index"))
@@ -62,10 +72,10 @@ void main() {
     },
     act: (cubit) => cubit.getTopHeadlines(),
     verify: (cubit) {
-      final cubitState = cubit.state as TopHeadlinesLoaded;
-      expect(cubitState.topHeadlines.length, 10);
-      expect(cubitState.topHeadlines.first.title, "0");
-      expect(cubitState.topHeadlines.last.title, "9");
+      final cubitState = cubit.state as Loaded;
+      expect(cubitState.viewState.length, 10);
+      expect(cubitState.viewState.first.title, "0");
+      expect(cubitState.viewState.last.title, "9");
     },
   );
 }


### PR DESCRIPTION
# Short Description
On this PR we are aiming for introducing [freezed](https://pub.dev/packages/freezed).

Freezed could mainly contribute towards:

* Creation of data classes with minimum effort
* As an alternative for the missing `sealed class / union types` on `dart`
* Facilitation on object clonation by using `copyWith`

# What changes in the code?
In order to operate with `freezer` data models / sealed classes needs to be annotated with `@freezed`. 
`Freezed` understand `json_serialization` but there is a bit of work to do in order to interoperate (we need it for retrofit)

Look at [ArticlesState](https://github.com/novoda/multiplatform-playground/blob/ffbbb062ae44856c1712065833b94aac319f1cd7/flutter/news/lib/features/frontpage/presentation/bloc/top_headlines_state.dart) for a reference on how implementing `sealed classes`

Look at [Articles](https://github.com/novoda/multiplatform-playground/blob/ffbbb062ae44856c1712065833b94aac319f1cd7/flutter/news/lib/features/frontpage/domain/entities/article.dart) for a reference on how implementing `data classes`

I have additionally reworked the `Result` class, as it is now a `sealed class` with some method extension that could make life a bit easier

# Did you test?
Yes, well, I adapted the tests to the new models, which requires named arguments for example