### PR TITLE
Enforce usage of trailing commas

### DIFF
--- a/flutter/news/analysis_options.yaml
+++ b/flutter/news/analysis_options.yaml
@@ -24,6 +24,7 @@ linter:
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    require_trailing_commas: true
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/flutter/news/lib/core/error/failures.dart
+++ b/flutter/news/lib/core/error/failures.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+
 part 'failures.freezed.dart';
 
 abstract class InternalFailure {}

--- a/flutter/news/lib/core/news_api_client.dart
+++ b/flutter/news/lib/core/news_api_client.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:news/features/frontpage/domain/entities/base_news_response.dart';
 import 'package:retrofit/retrofit.dart';
+
 part 'news_api_client.g.dart';
 
 @RestApi(baseUrl: "https://newsapi.org")

--- a/flutter/news/lib/core/result.dart
+++ b/flutter/news/lib/core/result.dart
@@ -1,6 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:news/core/error/failures.dart';
 
-import 'error/failures.dart';
 part 'result.freezed.dart';
 
 @freezed

--- a/flutter/news/lib/features/frontpage/data/datasource/articles_local_data_source.dart
+++ b/flutter/news/lib/features/frontpage/data/datasource/articles_local_data_source.dart
@@ -1,10 +1,8 @@
 import 'dart:convert';
 
+import 'package:news/core/error/failures.dart';
 import 'package:news/core/result.dart';
-
-import '../../../../core/error/failures.dart';
-import '../../../../core/result.dart';
-import '../../domain/entities/article.dart';
+import 'package:news/features/frontpage/domain/entities/article.dart';
 
 // TODO to include a real persistence layer, something like a database using something like https://drift.simonbinder.eu
 class ArticlesLocalDataSource {
@@ -23,12 +21,18 @@ class ArticlesLocalDataSource {
       if (articles.isNotEmpty) {
         return Future.value(Result<List<Article>>.success(data: articles));
       } else {
-        return Future.value(const Result<List<Article>>.failure(
-            failure: CacheFailure(message: "No headlines saved")));
+        return Future.value(
+          const Result<List<Article>>.failure(
+            failure: CacheFailure(message: "No headlines saved"),
+          ),
+        );
       }
     } catch (e) {
-      return Future.value(const Result<List<Article>>.failure(
-          failure: CacheFailure(message: "Error decoding stored headlines")));
+      return Future.value(
+        const Result<List<Article>>.failure(
+          failure: CacheFailure(message: "Error decoding stored headlines"),
+        ),
+      );
     }
   }
 

--- a/flutter/news/lib/features/frontpage/data/datasource/articles_remote_data_source.dart
+++ b/flutter/news/lib/features/frontpage/data/datasource/articles_remote_data_source.dart
@@ -11,8 +11,11 @@ class ArticlesRemoteDataSource {
     var result = await client
         .topHeadLines()
         .then((value) => Result<List<Article>>.success(data: value.articles))
-        .catchError((error) => const Result<List<Article>>.failure(
-            failure: ServerFailure(message: "Unable to read news from API")));
+        .catchError(
+          (error) => const Result<List<Article>>.failure(
+            failure: ServerFailure(message: "Unable to read news from API"),
+          ),
+        );
 
     return result;
   }

--- a/flutter/news/lib/features/frontpage/data/repositories/articles_repository.dart
+++ b/flutter/news/lib/features/frontpage/data/repositories/articles_repository.dart
@@ -1,16 +1,17 @@
 import 'package:news/core/language_extensions.dart';
 import 'package:news/core/result.dart';
-
-import '../../domain/entities/article.dart';
-import '../datasource/articles_local_data_source.dart';
-import '../datasource/articles_remote_data_source.dart';
+import 'package:news/features/frontpage/data/datasource/articles_local_data_source.dart';
+import 'package:news/features/frontpage/data/datasource/articles_remote_data_source.dart';
+import 'package:news/features/frontpage/domain/entities/article.dart';
 
 class ArticlesRepository {
   final ArticlesLocalDataSource localDataSource;
   final ArticlesRemoteDataSource remoteDataSource;
 
-  ArticlesRepository(
-      {required this.localDataSource, required this.remoteDataSource});
+  ArticlesRepository({
+    required this.localDataSource,
+    required this.remoteDataSource,
+  });
 
   Future<Result<List<Article>>> everythingAbout(String query) {
     // TODO: implement getEverythingAbout

--- a/flutter/news/lib/features/frontpage/domain/entities/article.dart
+++ b/flutter/news/lib/features/frontpage/domain/entities/article.dart
@@ -6,15 +6,17 @@ part 'article.g.dart';
 
 @freezed
 class Article with _$Article {
-  const factory Article(
-      {required Source source,
-      required String author,
-      required String title,
-      required String description,
-      required String url,
-      required String urlToImage,
-      required String publishedAt,
-      required String content}) = _Article;
+  const factory Article({
+    required Source source,
+    required String author,
+    required String title,
+    required String description,
+    required String url,
+    required String urlToImage,
+    required String publishedAt,
+    required String content,
+  }) = _Article;
 
-  factory Article.fromJson(Map<String, dynamic> json) => _$ArticleFromJson(json);
+  factory Article.fromJson(Map<String, dynamic> json) =>
+      _$ArticleFromJson(json);
 }

--- a/flutter/news/lib/features/frontpage/domain/entities/base_news_response.dart
+++ b/flutter/news/lib/features/frontpage/domain/entities/base_news_response.dart
@@ -1,14 +1,16 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:news/features/frontpage/domain/entities/article.dart';
+
 part 'base_news_response.freezed.dart';
 part 'base_news_response.g.dart';
 
 @freezed
 class BaseNewsResponse with _$BaseNewsResponse {
-  const factory BaseNewsResponse(
-      {required String status,
-      required int totalResults,
-      required List<Article> articles}) = _BaseNewsResponse;
+  const factory BaseNewsResponse({
+    required String status,
+    required int totalResults,
+    required List<Article> articles,
+  }) = _BaseNewsResponse;
 
   factory BaseNewsResponse.fromJson(Map<String, dynamic> json) =>
       _$BaseNewsResponseFromJson(json);

--- a/flutter/news/lib/features/frontpage/domain/usecases/get_everything_about.dart
+++ b/flutter/news/lib/features/frontpage/domain/usecases/get_everything_about.dart
@@ -1,7 +1,6 @@
 import 'package:news/core/result.dart';
+import 'package:news/features/frontpage/data/repositories/articles_repository.dart';
 import 'package:news/features/frontpage/domain/entities/article.dart';
-
-import '../../data/repositories/articles_repository.dart';
 
 class GetEverythingAbout {
   final ArticlesRepository repository;

--- a/flutter/news/lib/features/frontpage/presentation/bloc/articles_cubit.dart
+++ b/flutter/news/lib/features/frontpage/presentation/bloc/articles_cubit.dart
@@ -15,7 +15,8 @@ class ArticlesCubit extends Cubit<ArticlesState> {
     final result = await repository.topHeadlines();
     result.when(
       success: (data) => {
-        emit(ArticlesState.loaded(
+        emit(
+          ArticlesState.loaded(
             viewState: data
                 .take(10)
                 .map(
@@ -25,7 +26,9 @@ class ArticlesCubit extends Cubit<ArticlesState> {
                     imageUrl: article.urlToImage,
                   ),
                 )
-                .toList()))
+                .toList(),
+          ),
+        )
       },
       failure: (failure) => emit(const ArticlesState.error()),
     );

--- a/flutter/news/test/features/frontpage/data/datasource/articles_local_data_source_test.dart
+++ b/flutter/news/test/features/frontpage/data/datasource/articles_local_data_source_test.dart
@@ -17,14 +17,15 @@ void main() {
 
   final articles = [
     const Article(
-        source: Source(id: "id", name: "local"),
-        author: "author",
-        title: "title",
-        description: "description",
-        url: "url",
-        urlToImage: "urlToImage",
-        publishedAt: "publishedAt",
-        content: "content")
+      source: Source(id: "id", name: "local"),
+      author: "author",
+      title: "title",
+      description: "description",
+      url: "url",
+      urlToImage: "urlToImage",
+      publishedAt: "publishedAt",
+      content: "content",
+    )
   ];
 
   test(
@@ -47,9 +48,10 @@ void main() {
       var result = await localDataSource.topHeadLines();
 
       expect(
-          result,
-          const CacheFailure(message: "No headlines saved")
-              .asFailure<List<Article>>());
+        result,
+        const CacheFailure(message: "No headlines saved")
+            .asFailure<List<Article>>(),
+      );
     },
   );
 
@@ -64,9 +66,10 @@ void main() {
       var result = await localDataSource.topHeadLines();
 
       expect(
-          result,
-          const CacheFailure(message: "Error decoding stored headlines")
-              .asFailure<List<Article>>());
+        result,
+        const CacheFailure(message: "Error decoding stored headlines")
+            .asFailure<List<Article>>(),
+      );
     },
   );
 }

--- a/flutter/news/test/features/frontpage/data/datasource/articles_remote_data_source_test.dart
+++ b/flutter/news/test/features/frontpage/data/datasource/articles_remote_data_source_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -8,6 +9,7 @@ import 'package:news/core/result.dart';
 import 'package:news/features/frontpage/data/datasource/articles_remote_data_source.dart';
 import 'package:news/features/frontpage/domain/entities/article.dart';
 import 'package:news/features/frontpage/domain/entities/base_news_response.dart';
+
 import '../../../../core/fixtures/fixture_reader.dart';
 import 'articles_remote_data_source_test.mocks.dart';
 
@@ -42,9 +44,10 @@ void main() {
       final result = await remoteDataSource.topHeadLines();
 
       expect(
-          result,
-          const ServerFailure(message: "Unable to read news from API")
-              .asFailure<List<Article>>());
+        result,
+        const ServerFailure(message: "Unable to read news from API")
+            .asFailure<List<Article>>(),
+      );
     },
   );
 }

--- a/flutter/news/test/features/frontpage/data/models/articles_model_test.dart
+++ b/flutter/news/test/features/frontpage/data/models/articles_model_test.dart
@@ -9,16 +9,17 @@ import '../../../../core/fixtures/fixture_reader.dart';
 
 void main() {
   const article = Article(
-      source: Source(id: null, name: "Lifehacker.com"),
-      author: 'Jeff Somers',
-      title: "Is the Crypto Bubble Going to Burst?",
-      description: "Even if you aren’t paying attention to Bitcoin",
-      url:
-          "https://lifehacker.com/is-the-crypto-bubble-going-to-burst-1848475768",
-      urlToImage:
-          "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/976a59b09e0e681e692bd7517498e3f2.jpg",
-      publishedAt: "2022-02-09T16:00:00Z",
-      content: "Even if you arent paying attention to Bitcoin");
+    source: Source(id: null, name: "Lifehacker.com"),
+    author: 'Jeff Somers',
+    title: "Is the Crypto Bubble Going to Burst?",
+    description: "Even if you aren’t paying attention to Bitcoin",
+    url:
+        "https://lifehacker.com/is-the-crypto-bubble-going-to-burst-1848475768",
+    urlToImage:
+        "https://i.kinja-img.com/gawker-media/image/upload/c_fill,f_auto,fl_progressive,g_center,h_675,pg_1,q_80,w_1200/976a59b09e0e681e692bd7517498e3f2.jpg",
+    publishedAt: "2022-02-09T16:00:00Z",
+    content: "Even if you arent paying attention to Bitcoin",
+  );
 
   const response =
       BaseNewsResponse(status: "ok", totalResults: 1, articles: [article]);

--- a/flutter/news/test/features/frontpage/data/repositories/articles_repository_test.dart
+++ b/flutter/news/test/features/frontpage/data/repositories/articles_repository_test.dart
@@ -12,43 +12,50 @@ import 'package:news/features/frontpage/domain/entities/source.dart';
 import 'articles_repository_test.mocks.dart';
 
 @GenerateMocks([ArticlesLocalDataSource])
-@GenerateMocks([
-  ArticlesRemoteDataSource
-], customMocks: [
-  MockSpec<ArticlesRemoteDataSource>(
-      as: #MockArticlesRemoteDataSourceForTest, returnNullOnMissingStub: true),
-])
+@GenerateMocks(
+  [ArticlesRemoteDataSource],
+  customMocks: [
+    MockSpec<ArticlesRemoteDataSource>(
+      as: #MockArticlesRemoteDataSourceForTest,
+      returnNullOnMissingStub: true,
+    ),
+  ],
+)
 void main() {
   late ArticlesRepository repository;
   late MockArticlesRemoteDataSource remoteDataSource;
   late MockArticlesLocalDataSource localDataSource;
   const remoteArticles = [
     Article(
-        source: Source(id: "id", name: "remote"),
-        author: "author",
-        title: "title",
-        description: "description",
-        url: "url",
-        urlToImage: "urlToImage",
-        publishedAt: "publishedAt",
-        content: "content")
+      source: Source(id: "id", name: "remote"),
+      author: "author",
+      title: "title",
+      description: "description",
+      url: "url",
+      urlToImage: "urlToImage",
+      publishedAt: "publishedAt",
+      content: "content",
+    )
   ];
   const localArticles = [
     Article(
-        source: Source(id: "id", name: "local"),
-        author: "author",
-        title: "title",
-        description: "description",
-        url: "url",
-        urlToImage: "urlToImage",
-        publishedAt: "publishedAt",
-        content: "content")
+      source: Source(id: "id", name: "local"),
+      author: "author",
+      title: "title",
+      description: "description",
+      url: "url",
+      urlToImage: "urlToImage",
+      publishedAt: "publishedAt",
+      content: "content",
+    )
   ];
   setUp(() {
     remoteDataSource = MockArticlesRemoteDataSource();
     localDataSource = MockArticlesLocalDataSource();
     repository = ArticlesRepository(
-        remoteDataSource: remoteDataSource, localDataSource: localDataSource);
+      remoteDataSource: remoteDataSource,
+      localDataSource: localDataSource,
+    );
   });
 
   test(
@@ -69,9 +76,11 @@ void main() {
   test(
     'GIVEN remote fetch will fail WHEN getting top articles THEN does not saves articles on local AND returns local articles',
     () async {
-      when(remoteDataSource.topHeadLines()).thenAnswer((realInvocation) async =>
-          const ServerFailure(message: "Failure reading from server")
-              .asFailure<List<Article>>());
+      when(remoteDataSource.topHeadLines()).thenAnswer(
+        (realInvocation) async =>
+            const ServerFailure(message: "Failure reading from server")
+                .asFailure<List<Article>>(),
+      );
       when(localDataSource.topHeadLines())
           .thenAnswer((realInvocation) async => localArticles.asSuccess());
 
@@ -87,16 +96,19 @@ void main() {
     () async {
       when(remoteDataSource.topHeadLines())
           .thenAnswer((realInvocation) async => remoteArticles.asSuccess());
-      when(localDataSource.topHeadLines()).thenAnswer((realInvocation) async =>
-          const CacheFailure(message: "Error reading from cache")
-              .asFailure<List<Article>>());
+      when(localDataSource.topHeadLines()).thenAnswer(
+        (realInvocation) async =>
+            const CacheFailure(message: "Error reading from cache")
+                .asFailure<List<Article>>(),
+      );
 
       var result = await repository.topHeadlines();
 
       expect(
-          result,
-          const CacheFailure(message: 'Error reading from cache')
-              .asFailure<List<Article>>());
+        result,
+        const CacheFailure(message: 'Error reading from cache')
+            .asFailure<List<Article>>(),
+      );
     },
   );
 }

--- a/flutter/news/test/features/frontpage/domain/usecases/get_everything_about_test.dart
+++ b/flutter/news/test/features/frontpage/domain/usecases/get_everything_about_test.dart
@@ -22,14 +22,15 @@ void main() {
     usecase = GetEverythingAbout(articlesRepository);
     matchingArticles = [
       const Article(
-          source: Source(id: "id", name: "name"),
-          author: "author",
-          title: "title",
-          description: "description",
-          url: "url",
-          urlToImage: "urlToImage",
-          publishedAt: "publishedAt",
-          content: "content")
+        source: Source(id: "id", name: "name"),
+        author: "author",
+        title: "title",
+        description: "description",
+        url: "url",
+        urlToImage: "urlToImage",
+        publishedAt: "publishedAt",
+        content: "content",
+      )
     ];
     query = "peace";
   });
@@ -49,16 +50,18 @@ void main() {
   test(
     'GIVEN getting everything about will fail WHEN calling use case THEN returns failure ',
     () async {
-      when(articlesRepository.everythingAbout(query)).thenAnswer((_) async =>
-          const ServerFailure(message: "Error on server")
-              .asFailure<List<Article>>());
+      when(articlesRepository.everythingAbout(query)).thenAnswer(
+        (_) async => const ServerFailure(message: "Error on server")
+            .asFailure<List<Article>>(),
+      );
 
       final result = await usecase.everythingAbout(query);
 
       expect(
-          result,
-          const ServerFailure(message: "Error on server")
-              .asFailure<List<Article>>());
+        result,
+        const ServerFailure(message: "Error on server")
+            .asFailure<List<Article>>(),
+      );
     },
   );
 }

--- a/flutter/news/test/features/frontpage/domain/usecases/get_top_headlines_test.dart
+++ b/flutter/news/test/features/frontpage/domain/usecases/get_top_headlines_test.dart
@@ -21,14 +21,15 @@ void main() {
     usecase = GetTopHeadlines(articlesRepository);
     topArticles = [
       const Article(
-          source: Source(id: "id", name: "name"),
-          author: "author",
-          title: "title",
-          description: "description",
-          url: "url",
-          urlToImage: "urlToImage",
-          publishedAt: "publishedAt",
-          content: "content")
+        source: Source(id: "id", name: "name"),
+        author: "author",
+        title: "title",
+        description: "description",
+        url: "url",
+        urlToImage: "urlToImage",
+        publishedAt: "publishedAt",
+        content: "content",
+      )
     ];
   });
 
@@ -47,16 +48,18 @@ void main() {
   test(
     'GIVEN reading top headlines will faill WHEN reading top articles THEN returns failure',
     () async {
-      when(articlesRepository.topHeadlines()).thenAnswer((_) async =>
-          const ServerFailure(message: "Error reading from server")
-              .asFailure<List<Article>>());
+      when(articlesRepository.topHeadlines()).thenAnswer(
+        (_) async => const ServerFailure(message: "Error reading from server")
+            .asFailure<List<Article>>(),
+      );
 
       final result = await usecase.topHeadlines();
 
       expect(
-          result,
-          const ServerFailure(message: "Error reading from server")
-              .asFailure<List<Article>>());
+        result,
+        const ServerFailure(message: "Error reading from server")
+            .asFailure<List<Article>>(),
+      );
     },
   );
 }

--- a/flutter/news/test/features/frontpage/presentation/bloc/articles_cubit_test.dart
+++ b/flutter/news/test/features/frontpage/presentation/bloc/articles_cubit_test.dart
@@ -32,13 +32,15 @@ void main() {
     act: (cubit) => cubit.getTopHeadlines(),
     expect: () => <ArticlesState>[
       const ArticlesState.loading(),
-      const ArticlesState.loaded(viewState: [
-        TopHeadlineViewState(
-          title: "title",
-          url: "url",
-          imageUrl: "image",
-        )
-      ])
+      const ArticlesState.loaded(
+        viewState: [
+          TopHeadlineViewState(
+            title: "title",
+            url: "url",
+            imageUrl: "image",
+          )
+        ],
+      )
     ],
   );
 
@@ -65,9 +67,10 @@ void main() {
     'WHEN response is successful '
     'THEN verify View State is limited to the first 10 elements',
     build: () {
-      when(repository.topHeadlines()).thenAnswer((_) async =>
-          List.generate(15, (index) => Stub.article(title: "$index"))
-              .asSuccess());
+      when(repository.topHeadlines()).thenAnswer(
+        (_) async => List.generate(15, (index) => Stub.article(title: "$index"))
+            .asSuccess(),
+      );
       return ArticlesCubit(repository: repository);
     },
     act: (cubit) => cubit.getTopHeadlines(),


### PR DESCRIPTION
# Short Description
Do you like `trailing commas`? this PR enforces them

# What changes in the code?
A new lint rule forcing `trailing commas` and fixing all the warnings as a result of it

