### PR TITLE
CQRS - Creation of ViewState from information aggregated from different sources

### DIFF
--- a/flutter/news/lib/core/error/failures.dart
+++ b/flutter/news/lib/core/error/failures.dart
@@ -2,7 +2,9 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'failures.freezed.dart';
 
-abstract class InternalFailure {}
+abstract class InternalFailure {
+  final String message = "";
+}
 
 @freezed
 class ServerFailure with _$ServerFailure implements InternalFailure {

--- a/flutter/news/lib/core/error/failures.dart
+++ b/flutter/news/lib/core/error/failures.dart
@@ -3,15 +3,17 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'failures.freezed.dart';
 
 abstract class InternalFailure {
-  final String message = "";
+  final String message;
+
+  InternalFailure(this.message);
 }
 
 @freezed
-class ServerFailure with _$ServerFailure implements InternalFailure {
+abstract class ServerFailure extends InternalFailure with _$ServerFailure {
   const factory ServerFailure({required String message}) = _ServerFailure;
 }
 
 @freezed
-class CacheFailure with _$CacheFailure implements InternalFailure {
+abstract class CacheFailure extends InternalFailure with _$CacheFailure {
   const factory CacheFailure({required String message}) = _CacheFailure;
 }

--- a/flutter/news/lib/core/language_extensions.dart
+++ b/flutter/news/lib/core/language_extensions.dart
@@ -17,4 +17,24 @@ extension FutureExtension<T> on Future<Result<T>> {
           failure: (theFailure) => failure(theFailure),
         ),
       );
+
+  Future<Result<R>> mapSuccess<R>(
+    FutureOr<Result<R>> Function(T value) success,
+  ) =>
+      then(
+        (value) => value.when(
+          success: (data) => success(data),
+          failure: (failure) => failure.asFailure<R>(),
+        ),
+      );
+
+  Future<Result<T>> mapFailure(
+    FutureOr<Result<T>> Function(InternalFailure failure) failure,
+  ) =>
+      then(
+        (value) => value.when(
+          success: (data) => data.asSuccess(),
+          failure: (theFailure) => failure(theFailure),
+        ),
+      );
 }

--- a/flutter/news/lib/features/frontpage/data/datasource/articles_local_data_source.dart
+++ b/flutter/news/lib/features/frontpage/data/datasource/articles_local_data_source.dart
@@ -4,24 +4,25 @@ import 'package:news/core/error/failures.dart';
 import 'package:news/core/news_database_client.dart';
 import 'package:news/core/result.dart';
 import 'package:news/features/frontpage/domain/entities/article.dart';
+import 'package:rxdart/rxdart.dart';
 
 // TODO to include a real persistence layer, something like a database using something like https://drift.simonbinder.eu
 class ArticlesLocalDataSource {
-  StreamController<List<Article>>? _controller;
+  BehaviorSubject<List<Article>>? _subject;
   final DB _db;
 
   ArticlesLocalDataSource(this._db);
 
   Stream<List<Article>> topHeadLines() {
-    _controller ??= StreamController(
-      onListen: () => _db.read().then((articles) => _controller!.add(articles)),
+    _subject ??= BehaviorSubject(
+      onListen: () => _db.read().then((articles) => _subject!.add(articles)),
     );
-    return _controller!.stream;
+    return _subject!.stream;
   }
 
   Future<Result<void>> save(List<Article> topHeadlines) => _db
       .save(topHeadlines)
-      .then((value) => _controller?.add(topHeadlines))
+      .then((value) => _subject?.add(topHeadlines))
       .then((result) => Result<void>.completed())
       .catchError(
         (error) => const Result<void>.failure(

--- a/flutter/news/lib/features/frontpage/data/repositories/articles_repository.dart
+++ b/flutter/news/lib/features/frontpage/data/repositories/articles_repository.dart
@@ -17,8 +17,7 @@ class ArticlesRepository {
 
   Stream<List<Article>> topHeadlines() => _localDataSource.topHeadLines();
 
-  Future<Result<void>> sync() => _remoteDataSource.topHeadLines().when(
-        success: (data) => _localDataSource.save(data),
-        failure: (failure) => failure.asFailure<void>(),
-      );
+  Future<Result<void>> sync() => _remoteDataSource
+      .topHeadLines()
+      .mapSuccess((data) => _localDataSource.save(data));
 }

--- a/flutter/news/lib/features/frontpage/presentation/bloc/articles_cubit.dart
+++ b/flutter/news/lib/features/frontpage/presentation/bloc/articles_cubit.dart
@@ -1,43 +1,45 @@
 import 'dart:async';
 
 import 'package:bloc/bloc.dart';
+import 'package:news/core/error/failures.dart';
 import 'package:news/core/language_extensions.dart';
 import 'package:news/features/frontpage/domain/usecases/get_top_headlines.dart';
 import 'package:news/features/frontpage/presentation/bloc/top_headlines_state.dart';
-import 'package:news/features/frontpage/presentation/bloc/top_headlines_viewstate.dart';
+import 'package:rxdart/rxdart.dart';
 
 class ArticlesCubit extends Cubit<ArticlesState> {
   final GetTopHeadlines _useCase;
-  StreamSubscription<ArticlesState>? _subscription;
+  late final StreamSubscription<ArticlesState> _subscription;
+  final BehaviorSubject<bool> _isLoading = BehaviorSubject()..add(false);
+  final BehaviorSubject<InternalFailure?> _error = BehaviorSubject()..add(null);
 
   ArticlesCubit(this._useCase) : super(const ArticlesState.initial());
 
+  //command
   void sync() async {
-    emit(const ArticlesState.loading());
-    await _useCase.sync().when(
-          success: (_) => doNothing(
-            because: "On this case we'll receive items on the subscription",
-          ),
-          failure: (failure) => emit(const ArticlesState.error()),
-        );
+    _isLoading.add(true);
+    await _useCase
+        .sync()
+        .when(
+          success: (_) => _error.add(null),
+          failure: (failure) => _error.add(failure),
+        )
+        .whenComplete(() => _isLoading.add(false));
   }
 
+  //query
   void init() {
-    _subscription = _useCase
-        .topHeadlines()
-        .map(
-          (data) => data
-              .take(10)
-              .map((article) => TopHeadlineViewState.from(article: article))
-              .toList(),
-        )
-        .map((viewState) => ArticlesState.loaded(viewState: viewState))
-        .listen(emit);
+    _subscription = Rx.combineLatest3(
+      _useCase.topHeadlines(),
+      _isLoading.stream,
+      _error.stream,
+      ArticlesState.from,
+    ).listen(emit);
   }
 
   @override
   Future<void> close() {
-    _subscription?.cancel();
+    _subscription.cancel();
     return super.close();
   }
 }

--- a/flutter/news/lib/features/frontpage/presentation/bloc/top_headlines_state.dart
+++ b/flutter/news/lib/features/frontpage/presentation/bloc/top_headlines_state.dart
@@ -1,6 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:news/core/error/failures.dart';
 import 'package:news/features/frontpage/domain/entities/article.dart';
+import 'package:news/features/frontpage/presentation/bloc/articles_cubit.dart';
 import 'package:news/features/frontpage/presentation/bloc/top_headlines_viewstate.dart';
 
 part 'top_headlines_state.freezed.dart';
@@ -16,20 +16,20 @@ class ArticlesState with _$ArticlesState {
 
   factory ArticlesState.from(
     List<Article> articles,
-    bool isLoading,
-    InternalFailure? failure,
+    ActionStatus status,
   ) {
-    if (isLoading) {
-      return const ArticlesState.loading();
-    } else if (failure != null) {
-      return const ArticlesState.error();
-    } else {
-      return ArticlesState.loaded(
-        viewState: articles
-            .map((e) => TopHeadlineViewState.from(article: e))
-            .take(10)
-            .toList(),
-      );
+    switch (status) {
+      case ActionStatus.loading:
+        return const ArticlesState.loading();
+      case ActionStatus.error:
+        return const ArticlesState.error();
+      case ActionStatus.idle:
+        return ArticlesState.loaded(
+          viewState: articles
+              .map((e) => TopHeadlineViewState.from(article: e))
+              .take(10)
+              .toList(),
+        );
     }
   }
 }

--- a/flutter/news/lib/features/frontpage/presentation/bloc/top_headlines_state.dart
+++ b/flutter/news/lib/features/frontpage/presentation/bloc/top_headlines_state.dart
@@ -1,4 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:news/core/error/failures.dart';
+import 'package:news/features/frontpage/domain/entities/article.dart';
 import 'package:news/features/frontpage/presentation/bloc/top_headlines_viewstate.dart';
 
 part 'top_headlines_state.freezed.dart';
@@ -11,4 +13,23 @@ class ArticlesState with _$ArticlesState {
     required List<TopHeadlineViewState> viewState,
   }) = _Loaded;
   const factory ArticlesState.error() = _Error;
+
+  factory ArticlesState.from(
+    List<Article> articles,
+    bool isLoading,
+    InternalFailure? failure,
+  ) {
+    if (isLoading) {
+      return const ArticlesState.loading();
+    } else if (failure != null) {
+      return const ArticlesState.error();
+    } else {
+      return ArticlesState.loaded(
+        viewState: articles
+            .map((e) => TopHeadlineViewState.from(article: e))
+            .take(10)
+            .toList(),
+      );
+    }
+  }
 }

--- a/flutter/news/pubspec.yaml
+++ b/flutter/news/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   json_annotation: ^4.4.0
   bloc_test: ^9.0.1
   freezed_annotation: ^1.1.0
+  rxdart: ^0.27.3
 
 dev_dependencies:
   flutter_test:
@@ -49,7 +50,7 @@ flutter:
   #   - images/a_dot_ham.jpeg
 
   assets:
-    - .secrets_env  
+    - .secrets_env
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.

--- a/flutter/news/test/features/frontpage/presentation/bloc/articles_cubit_test.dart
+++ b/flutter/news/test/features/frontpage/presentation/bloc/articles_cubit_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -15,59 +17,72 @@ import 'articles_cubit_test.mocks.dart';
 @GenerateMocks([GetTopHeadlines])
 void main() {
   final GetTopHeadlines useCase = MockGetTopHeadlines();
-  final articles = List.generate(15, (index) => Stub.article(title: "$index"));
+  final oldArticles =
+      List.generate(15, (index) => Stub.article(title: "old $index"));
+  final newArticles =
+      List.generate(15, (index) => Stub.article(title: "new $index"));
   blocTest<ArticlesCubit, ArticlesState>(
-    'GIVEN sync will succeed '
+    'GIVEN old data is present AND sync will succeed AND new data is retrieved'
     'WHEN syncing is triggered '
-    'THEN emits [Loading]',
-    build: () {
-      when(useCase.sync()).thenAnswer(
-        (_) async => Result.completed(),
-      );
-      return ArticlesCubit(useCase);
-    },
-    act: (cubit) => cubit.sync(),
-    expect: () => <ArticlesState>[
-      const ArticlesState.loading(),
-    ],
-  );
-
-  blocTest<ArticlesCubit, ArticlesState>(
-    'GIVEN syncing will fail '
-    'WHEN syncing is triggered '
-    'THEN emits [Loading, Error]',
-    build: () {
-      when(useCase.sync()).thenAnswer(
-        (_) async => const CacheFailure(message: "No headlines saved")
-            .asFailure<List<Article>>(),
-      );
-      return ArticlesCubit(useCase);
-    },
-    act: (cubit) => cubit.sync(),
-    expect: () => <ArticlesState>[
-      const ArticlesState.loading(),
-      const ArticlesState.error(),
-    ],
-  );
-
-  blocTest<ArticlesCubit, ArticlesState>(
-    'GIVEN will return articles '
-    'WHEN response is successful '
-    'THEN emits Loaded with data limited to 10 items',
-    build: () {
+    'THEN emits [Loaded (old), Loading, Loaded (new)]',
+    setUp: () {
+      var controller = StreamController<List<Article>>()..add(oldArticles);
       when(useCase.topHeadlines()).thenAnswer(
-        (_) => Stream.value(articles),
+        (_) => controller.stream,
       );
-      return ArticlesCubit(useCase);
+      when(useCase.sync()).thenAnswer(
+        (_) => Future.value(Result.completed())
+            .whenComplete(() => controller.add(newArticles)),
+      );
     },
-    act: (cubit) => cubit.init(),
+    build: () => ArticlesCubit(useCase),
+    act: (cubit) => cubit
+      ..init()
+      ..sync(),
     expect: () => <ArticlesState>[
       ArticlesState.loaded(
-        viewState: articles
+        viewState: oldArticles
+            .getRange(0, 10)
+            .map((article) => TopHeadlineViewState.from(article: article))
+            .toList(),
+      ),
+      const ArticlesState.loading(),
+      ArticlesState.loaded(
+        viewState: newArticles
             .getRange(0, 10)
             .map((article) => TopHeadlineViewState.from(article: article))
             .toList(),
       )
+    ],
+  );
+
+  blocTest<ArticlesCubit, ArticlesState>(
+    'GIVEN old data is present AND sync will fail'
+    'WHEN syncing is triggered '
+    'THEN emits [Loaded (old), Loading, Error]',
+    setUp: () {
+      var controller = StreamController<List<Article>>()..add(oldArticles);
+      when(useCase.topHeadlines()).thenAnswer(
+        (_) => controller.stream,
+      );
+      when(useCase.sync()).thenAnswer(
+        (_) async => const ServerFailure(message: "Unable to read API")
+            .asFailure<void>(),
+      );
+    },
+    build: () => ArticlesCubit(useCase),
+    act: (cubit) => cubit
+      ..init()
+      ..sync(),
+    expect: () => <ArticlesState>[
+      ArticlesState.loaded(
+        viewState: oldArticles
+            .getRange(0, 10)
+            .map((article) => TopHeadlineViewState.from(article: article))
+            .toList(),
+      ),
+      const ArticlesState.loading(),
+      const ArticlesState.error()
     ],
   );
 }


### PR DESCRIPTION
# Short Description

This is a continuation of #26 

On this PR we are aiming to create the `view state` for news `article`s from data coming from "different sources".  
Let's focus on the `ArticlesCubit` implementation. 

Not much happens on `sync`, the difference there is that now instead of calling `emit` directly, we are posting `status` to a `BehaviorSubject<CommandStatus>`. This behavior subject will represent the "different source". 

On `init()` is where the real magic happens, we have two streams of information of different nature that we want to aggregate in order to form our view. 

1. We have a `Stream<CommandStatus>` which can be one of `idle, loading, error`. 
2. We also have a `Stream<List<Article>>`. 

Based on those two pieces of information we can now generate our `view state`; `ArticleStates.from(commandStatus, articles)` 

For the data aggregation we are using a handy `Rx` operator; `combineLatest`. This help us to generate new `view state` once one of the streams emits new data. https://reactivex.io/documentation/operators/combinelatest.html

# What changes in the code?

* Added extra extension functions on `Result`; for simplicity
* Included `RxDart`
* Does the mentioned changes on the `ArticlesCubit`

# Did you test?
Verified that the tests are still passing