### PR TITLE
Playground screen UI states

### DIFF
--- a/reactnative/RNPlayground/app/models/PlaygroundStore.ts
+++ b/reactnative/RNPlayground/app/models/PlaygroundStore.ts
@@ -1,0 +1,79 @@
+import { types } from "mobx-state-tree";
+import { delay } from "../utils/delay";
+
+const Content = types.model("Content", { number: 0 })
+const Loading = types.model("Loading")
+const Error = types.model("Error", { message: "" })
+const PlaygroundUiState = types
+    .model('PlaygroundUiState', {
+        loading: types.maybe(Loading),
+        error: types.maybe(Error),
+        content: types.maybe(Content)
+    })
+    .actions((self) => {
+        function clear() {
+            self.content = undefined
+            self.error = undefined
+            self.loading = undefined
+        }
+        function setLoading() {
+            clear()
+            self.loading = Loading.create()
+        }
+        function setError(error: string) {
+            clear()
+            self.error = Error.create({ message: error })
+        }
+        function setContent(number: number) {
+            clear()
+            self.content = Content.create({ number: number })
+        }
+        return {
+            setLoading, setError, setContent
+        }
+    })
+
+const initialLoading = () => PlaygroundUiState.create({ loading: Loading.create() })
+
+export const PlaygroundStoreModel = types
+    .model("PlaygroundStore")
+    .props({
+        uiState: types.optional(PlaygroundUiState, initialLoading)
+    })
+    .actions((store) => {
+        let interval = null
+
+        async function startCounter() {
+            store.uiState.setLoading()
+            await delay(1000)
+            console.log("START")
+
+            interval = setInterval(() => {
+                if (store.uiState.content) {
+                    const value = store.uiState.content.number
+                    if (value < 30) {
+                        store.uiState.setContent(value + 1)
+                    } else {
+                        store.uiState.setError("Encountered a fake error")
+                        stopCounter()
+                    }
+                } else {
+                    store.uiState.setContent(0)
+                }
+            }, 500)
+        }
+
+        function stopCounter() {
+            console.log("STOP")
+            clearInterval(interval)
+            interval = null
+        }
+        async function resetCounter() {
+            stopCounter()
+            startCounter()
+        }
+        return {
+            startCounter, stopCounter, resetCounter
+        }
+    })
+

--- a/reactnative/RNPlayground/app/models/RootStore.ts
+++ b/reactnative/RNPlayground/app/models/RootStore.ts
@@ -1,9 +1,11 @@
 import { Instance, SnapshotOut, types } from "mobx-state-tree"
+import { PlaygroundStoreModel } from "./PlaygroundStore"
 
 /**
  * A RootStore model.
  */
 export const RootStoreModel = types.model("RootStore").props({
+    playgroundStore: types.optional(PlaygroundStoreModel, {})
 })
 
 /**

--- a/reactnative/RNPlayground/app/navigators/AppNavigator.tsx
+++ b/reactnative/RNPlayground/app/navigators/AppNavigator.tsx
@@ -9,7 +9,7 @@ import {
   DefaultTheme,
   NavigationContainer,
 } from "@react-navigation/native"
-import { createMaterialBottomTabNavigator } from "@react-navigation/material-bottom-tabs"
+import { createMaterialBottomTabNavigator, MaterialBottomTabScreenProps } from "@react-navigation/material-bottom-tabs"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useColorScheme } from "react-native"
@@ -41,6 +41,8 @@ export type NavigatorParamList = {
 }
 
 const Tab = createMaterialBottomTabNavigator<NavigatorParamList>()
+
+export type BaseScreenProps<T extends keyof NavigatorParamList> = MaterialBottomTabScreenProps<NavigatorParamList, T>
 
 function AppTabs() {
   const iconSize = 24

--- a/reactnative/RNPlayground/app/screens/AboutScreen.tsx
+++ b/reactnative/RNPlayground/app/screens/AboutScreen.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react"
 import { observer } from "mobx-react-lite"
 import { StackScreenProps } from "@react-navigation/stack"
-import { AppStackScreenProps } from "../navigators"
+import { BaseScreenProps } from "../navigators"
 import { Image, ImageStyle, TextStyle, View, ViewStyle } from "react-native"
 import {
   Text, Screen
@@ -10,26 +10,26 @@ import { isRTL } from "../i18n"
 import { colors, spacing } from "../theme"
 import { useSafeAreaInsetsStyle } from "../utils/useSafeAreaInsetsStyle"
 
-export const AboutScreen: FC<StackScreenProps<AppStackScreenProps, "About">> = observer(function AboutScreen() {
-    const $bottomContainerInsets = useSafeAreaInsetsStyle(["bottom"])
+export const AboutScreen: FC<BaseScreenProps<"About">> = observer(function AboutScreen() {
+  const $bottomContainerInsets = useSafeAreaInsetsStyle(["bottom"])
 
-    return (
-      <View style={$container}>
-        <View style={$topContainer}>
-          <Text
-            testID="welcome-heading"
-            style={$welcomeHeading}
-            tx="aboutScreen.readyForLaunch"
-            preset="heading"
-          />
-          <Text tx="aboutScreen.postscript" preset="subheading" />
-        </View>
-
-        <View style={[$bottomContainer, $bottomContainerInsets]}>
-          <Text tx="aboutScreen.exciting" size="md" />
-        </View>
+  return (
+    <View style={$container}>
+      <View style={$topContainer}>
+        <Text
+          testID="welcome-heading"
+          style={$welcomeHeading}
+          tx="aboutScreen.readyForLaunch"
+          preset="heading"
+        />
+        <Text tx="aboutScreen.postscript" preset="subheading" />
       </View>
-    )
+
+      <View style={[$bottomContainer, $bottomContainerInsets]}>
+        <Text tx="aboutScreen.exciting" size="md" />
+      </View>
+    </View>
+  )
 })
 
 const $container: ViewStyle = {

--- a/reactnative/RNPlayground/app/screens/PlaygroundScreen.tsx
+++ b/reactnative/RNPlayground/app/screens/PlaygroundScreen.tsx
@@ -1,16 +1,12 @@
 import * as React from "react"
 import { observer } from "mobx-react-lite"
 import { BaseScreenProps } from "../navigators"
-import { Image, ImageStyle, TextStyle, View, ViewStyle } from "react-native"
-import { Text, Screen, Button } from "../components"
-import { isRTL } from "../i18n"
+import { TextStyle, View, ViewStyle } from "react-native"
+import { Text, Button } from "../components"
 import { colors, spacing } from "../theme"
 import { useSafeAreaInsetsStyle } from "../utils/useSafeAreaInsetsStyle"
-import { useFocusEffect, useIsFocused } from "@react-navigation/core"
-import { action, makeAutoObservable, observable, when } from "mobx"
+import { useFocusEffect } from "@react-navigation/core"
 import { useStores } from "../models"
-import { EdgeInsets } from "react-native-safe-area-context"
-
 
 interface PlaygroundScreenProps extends BaseScreenProps<"Playground"> {
 }

--- a/reactnative/RNPlayground/app/screens/PlaygroundScreen.tsx
+++ b/reactnative/RNPlayground/app/screens/PlaygroundScreen.tsx
@@ -1,76 +1,112 @@
-import React, { FC } from "react"
+import * as React from "react"
 import { observer } from "mobx-react-lite"
-import { StackScreenProps } from "@react-navigation/stack"
-import { AppStackScreenProps } from "../navigators"
+import { BaseScreenProps } from "../navigators"
 import { Image, ImageStyle, TextStyle, View, ViewStyle } from "react-native"
-import {
-  Text, Screen
-} from "../components"
+import { Text, Screen, Button } from "../components"
 import { isRTL } from "../i18n"
 import { colors, spacing } from "../theme"
 import { useSafeAreaInsetsStyle } from "../utils/useSafeAreaInsetsStyle"
+import { useFocusEffect, useIsFocused } from "@react-navigation/core"
+import { action, makeAutoObservable, observable, when } from "mobx"
+import { useStores } from "../models"
+import { EdgeInsets } from "react-native-safe-area-context"
 
 
-export const PlaygroundScreen: FC<StackScreenProps<AppStackScreenProps, "Playground">> = observer(function PlaygroundScreen() {
-    const $bottomContainerInsets = useSafeAreaInsetsStyle(["bottom"])
+interface PlaygroundScreenProps extends BaseScreenProps<"Playground"> {
+}
 
-    return (
-       <View style={$container}>
-         <View style={$topContainer}>
-           <Text
-             testID="welcome-heading"
-             style={$welcomeHeading}
-             tx="playgroundScreen.readyForLaunch"
-             preset="heading"
-           />
-           <Text tx="playgroundScreen.postscript" preset="subheading" />
-         </View>
+export const PlaygroundScreen: React.FC<PlaygroundScreenProps> = observer((props) => {
+  const $bottomContainerInsets = useSafeAreaInsetsStyle(["bottom"])
+  const { playgroundStore } = useStores()
 
-         <View style={[$bottomContainer, $bottomContainerInsets]}>
-           <Text tx="playgroundScreen.exciting" size="md" />
-         </View>
-       </View>
-     )
- })
+  useFocusEffect(
+    React.useCallback(() => {
+      playgroundStore.startCounter()
+      return () => playgroundStore.stopCounter()
+    }, [playgroundStore])
+  )
 
- const $container: ViewStyle = {
-   flex: 1,
-   backgroundColor: colors.background,
- }
+  return <View style={$container}>
+    {
+      StateComponent(
+        $bottomContainerInsets,
+        playgroundStore.uiState,
+        () => playgroundStore.resetCounter()
+      )
+    }
+  </View>
+})
 
- const $topContainer: ViewStyle = {
-   flexShrink: 1,
-   flexGrow: 1,
-   flexBasis: "57%",
-   justifyContent: "center",
-   paddingHorizontal: spacing.large,
- }
+function StateComponent(insets, uiState, onResetClicked) {
+  const { loading, error, content } = uiState
+  if (loading) {
+    return LoadingComponent(insets)
+  } else if (error) {
+    return ErrorComponent(insets, error, onResetClicked)
+  } else if (content) {
+    return ContentComponent(insets, content, onResetClicked)
+  }
+  throw new Error(`UiState type is not handled ${JSON.stringify(uiState)}`)
+}
 
- const $bottomContainer: ViewStyle = {
-   flexShrink: 1,
-   flexGrow: 0,
-   flexBasis: "43%",
-   backgroundColor: colors.palette.neutral100,
-   borderTopLeftRadius: 16,
-   borderTopRightRadius: 16,
-   paddingHorizontal: spacing.large,
-   justifyContent: "space-around",
- }
- const $welcomeLogo: ImageStyle = {
-   height: 88,
-   width: "100%",
-   marginBottom: spacing.huge,
- }
+function ContentComponent(insets, content, onResetClicked) {
+  return <View>
+    <View style={$topContainer}>
+      <Text
+        testID="welcome-heading"
+        style={$welcomeHeading}
+        tx="playgroundScreen.readyForLaunch"
+        preset="heading"
+      />
+      <Text tx="playgroundScreen.postscript" preset="subheading" />
+    </View>
 
- const $welcomeFace: ImageStyle = {
-   height: 169,
-   width: 269,
-   position: "absolute",
-   bottom: -47,
-   right: -80,
-   transform: [{ scaleX: isRTL ? -1 : 1 }],
- }
+    <View style={[$bottomContainer, insets]}>
+      <Text tx="playgroundScreen.exciting" size="md" />
+      <Text text={`Value is: ${content.number}`} size="md" />
+      <Button text="Reset" onPress={onResetClicked} />
+    </View>
+  </View>
+}
 
- const $welcomeHeading: TextStyle = {
-   marginBottom: spacing.medium,
- }
+function ErrorComponent(insets, error, onResetClicked) {
+  return <View style={[insets]}>
+    <Text text={`ERROR: ${error.message}`} size="md" />
+    <Button text="Refresh" onPress={onResetClicked} />
+  </View>
+}
+
+function LoadingComponent(insets) {
+  return <View style={[insets, { justifyContent: "space-around", flexGrow: 1 }]}>
+    <Text text={`LOADING`} size="md" style={{ textAlign: "center" }} />
+  </View>
+}
+
+const $container: ViewStyle = {
+  flex: 1,
+  backgroundColor: colors.background,
+}
+
+const $topContainer: ViewStyle = {
+  flexShrink: 1,
+  flexGrow: 1,
+  flexBasis: "57%",
+  justifyContent: "center",
+  paddingHorizontal: spacing.large,
+}
+
+const $bottomContainer: ViewStyle = {
+  flexShrink: 1,
+  flexGrow: 0,
+  flexBasis: "43%",
+  backgroundColor: colors.palette.neutral100,
+  borderTopLeftRadius: 16,
+  borderTopRightRadius: 16,
+  paddingHorizontal: spacing.large,
+  justifyContent: "space-around",
+}
+
+const $welcomeHeading: TextStyle = {
+  marginBottom: spacing.medium,
+}
+

--- a/reactnative/RNPlayground/app/screens/WelcomeScreen.tsx
+++ b/reactnative/RNPlayground/app/screens/WelcomeScreen.tsx
@@ -5,6 +5,7 @@ import {
   Text,
 } from "../components"
 import { isRTL } from "../i18n"
+import { BaseScreenProps } from "../navigators"
 import { colors, spacing } from "../theme"
 import { useSafeAreaInsetsStyle } from "../utils/useSafeAreaInsetsStyle"
 
@@ -12,7 +13,7 @@ const welcomeLogo = require("../../assets/images/logo.png")
 const welcomeFace = require("../../assets/images/welcome-face.png")
 
 
-export const WelcomeScreen: FC<WelcomeScreenProps> = observer(function WelcomeScreen(
+export const WelcomeScreen: FC<BaseScreenProps<"Welcome">> = observer(function WelcomeScreen(
 ) {
 
   const $bottomContainerInsets = useSafeAreaInsetsStyle(["bottom"])


### PR DESCRIPTION
# Short Description
Adds UI states to the playground screen 

# What changes in the code?
The main goal was to learn how to define custom stores and data types with [`mobx-state-tree`](https://mobx-state-tree.js.org/intro/welcome) library.

Now there is a loading state that is followed by a content with auto-incremented number. When the number reaches 30 and error is shown. There is also a button to reset the counter. This should give us enough of a base to start adding some real code that fetches some data from somewhere and displays it on the screen.

# Did you test?
manually only, no idea how to write tests here yet

# paired with  
@Frankie-Boy at the beginning where nothing made sense